### PR TITLE
Allow `cargo:rustc-link-lib` value to be overriden by env var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "openni2-sys"
 version = "1.1.0"
 authors = ["Jesse Bees <jesse@toomanybees.com>"]
 build = "build.rs"
-links = "openni2"
 exclude = ["vendor/**/*"]
 description = "Rust bindings for OpenNI2"
 repository = "https://github.com/TooManyBees/openni2-sys"

--- a/README.md
+++ b/README.md
@@ -19,19 +19,6 @@ When building on Windows, the build script checks the presence of the env vars
 (A Windows OpenNI2 installation should also have the `OPENNI2_REDIST(64)` env
 var set, but it's not the location needed to correctly link.)
 
-# Runtime considerations
-
-For OSX, add `OPENNI2_REDIST(64)` (the location of `libOpenNI2.dylib`)
-to your `DYLD_LIBRARY_PATH` env var.
-
-For Linux, add `OPENNI2_REDIST(64)` (the location of `libOpenNI2.so`)
-to your `LD_LIBRARY_PATH` env var.
-
-For Windows, add `OPENNI2_REDIST(64)` to your `PATH`.
-
-Otherwise to avoid using shared locations, copy `OpenNI2.dll`,
-`libOpenNI2.dylib`, or `libOpenNI2.so` to the executable's directory.
-
 If your installation names the library something different than `openni2`,
 the name passed to the linker (i.e. `-lopenni2`), can be overriden with the
 `OPENNI2_LIBNAME` environment variable:
@@ -45,6 +32,18 @@ $ OPENNI2_REDIST64=/lib/libOpenNI2 OPENNI2_LIBNAME=OpenNI2 cargo build
     Finished dev [unoptimized + debuginfo] target(s) in 0.96s
 ```
 
+# Runtime considerations
+
+For OSX, add `OPENNI2_REDIST(64)` (the location of `libOpenNI2.dylib`)
+to your `DYLD_LIBRARY_PATH` env var.
+
+For Linux, add `OPENNI2_REDIST(64)` (the location of `libOpenNI2.so`)
+to your `LD_LIBRARY_PATH` env var.
+
+For Windows, add `OPENNI2_REDIST(64)` to your `PATH`.
+
+Otherwise to avoid using shared locations, copy `OpenNI2.dll`,
+`libOpenNI2.dylib`, or `libOpenNI2.so` to the executable's directory.
 
 # LICENSE
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ For Windows, add `OPENNI2_REDIST(64)` to your `PATH`.
 Otherwise to avoid using shared locations, copy `OpenNI2.dll`,
 `libOpenNI2.dylib`, or `libOpenNI2.so` to the executable's directory.
 
+If your installation names the library something different than `openni2`,
+the name passed to the linker (i.e. `-lopenni2`), can be overriden with the
+`OPENNI2_LIBNAME` environment variable:
+
+```
+$ OPENNI2_REDIST64=/lib/libOpenNI2 cargo build
+error: linking with `cc` failed: exit code: 1
+  = note: /usr/bin/ld: cannot find -lopeni2
+          collect2: error: ld returned 1 exit status
+$ OPENNI2_REDIST64=/lib/libOpenNI2 OPENNI2_LIBNAME=OpenNI2 cargo build
+    Finished dev [unoptimized + debuginfo] target(s) in 0.96s
+```
+
+
 # LICENSE
 
 These bindings are distributed under the MIT license, which I don't exactly

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,23 @@
 use std::env;
 
-#[cfg(windows)] const OPENNI2_DIR64: &str = "OPENNI2_LIB64";
-#[cfg(windows)] const OPENNI2_DIR: &str = "OPENNI2_LIB";
-#[cfg(not(windows))] const OPENNI2_DIR64: &str = "OPENNI2_REDIST64";
-#[cfg(not(windows))] const OPENNI2_DIR: &str = "OPENNI2_REDIST";
+#[cfg(windows)]
+const OPENNI2_DIR64: &str = "OPENNI2_LIB64";
+#[cfg(windows)]
+const OPENNI2_DIR: &str = "OPENNI2_LIB";
+#[cfg(not(windows))]
+const OPENNI2_DIR64: &str = "OPENNI2_REDIST64";
+#[cfg(not(windows))]
+const OPENNI2_DIR: &str = "OPENNI2_REDIST";
 
 fn main() {
     let openni2_dir = env::var(OPENNI2_DIR)
-                      .or(env::var(OPENNI2_DIR64))
-                      .expect(&format!("Required env var for dynamic libraries missing. Expected `{}` or `{}`.", OPENNI2_DIR, OPENNI2_DIR64));
+        .or(env::var(OPENNI2_DIR64))
+        .expect(&format!(
+            "Required env var for dynamic libraries missing. Expected `{}` or `{}`.",
+            OPENNI2_DIR, OPENNI2_DIR64
+        ));
+    let openni2_libname = env::var("OPENNI2_LIBNAME").unwrap_or("OpenNI2".to_string());
+
     println!("cargo:rustc-link-search=native={}", openni2_dir);
-    println!("cargo:rustc-link-lib=dylib=openni2");
+    println!("cargo:rustc-link-lib=dylib={}", openni2_libname);
 }


### PR DESCRIPTION
First, thank you so much for creating these bindings!  I use Kinects for art projects, and recently upgraded to Kinect V2 from the `freenect-rs` + Kinect V1 setup I was using before, and your OpenNI2 crates were really wonderful to use :slightly_smiling_face: 

I ran into issues building this on my system until I was able to override the library name, and would love to work with you to get my change added. 

#### Changes
- Removed `Cargo.toml`'s `links` field  as it appears to be unused since we're setting `cargo:rustc-link-lib` via `build.rs`
- If `OPENNI2_LIBNAME` is set, then that variable's value is passed into `cargo:rustc-link-lib` (and therefore the linker), otherwise it defaults to the current value: `openni2`.  I added this because on my system, it turns out the linker wanted `-lOpenNI2`
- Edit: Also, it appears as though `rustfmt` had some fun.

#### Example
```
$ OPENNI2_REDIST64=/lib/libOpenNI2 cargo build
error: linking with `cc` failed: exit code: 1
  = note: /usr/bin/ld: cannot find -lopenni2
          collect2: error: ld returned 1 exit status
$ OPENNI2_REDIST64=/lib/libOpenNI2 OPENNI2_LIBNAME=OpenNI2 cargo build
    Finished dev [unoptimized + debuginfo] target(s) in 0.96s
```

#### Note
I only tested this on one Linux distribution.